### PR TITLE
Extending multiprovider 

### DIFF
--- a/TileStache/Config.py
+++ b/TileStache/Config.py
@@ -124,6 +124,10 @@ class Configuration:
         self.dirpath = dirpath
         self.layers = {}
         
+        # adding custom_layer to extend multiprovider to support comma separated layernames
+        self.custom_layer_name = ","
+        self.custom_layer_dict = {'provider': {'class': 'TileStache.Goodies.VecTiles:MultiProvider', 'kwargs': {'names': []}}}
+        
         self.index = 'text/plain', 'TileStache bellows hello.'
 
 class Bounds:
@@ -204,7 +208,7 @@ def buildConfiguration(config_dict, dirpath='.'):
         URL including the "file://" prefix.
     """
     scheme, h, path, p, q, f = urlparse(dirpath)
-    
+
     if scheme in ('', 'file'):
         sys.path.insert(0, path)
     
@@ -215,6 +219,8 @@ def buildConfiguration(config_dict, dirpath='.'):
     
     for (name, layer_dict) in config_dict.get('layers', {}).items():
         config.layers[name] = _parseConfigfileLayer(layer_dict, config, dirpath)
+
+    config.layers[config.custom_layer_name] = _parseConfigfileLayer(config.custom_layer_dict, config, dirpath)
 
     if 'index' in config_dict:
         index_href = urljoin(dirpath, config_dict['index'])

--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -195,7 +195,11 @@ class MultiProvider:
     def __init__(self, layer, names):
         self.layer = layer
         self.names = names
-        
+    
+    def __call__(self, layer, names):
+        self.layer = layer
+        self.names = names
+
     def renderTile(self, width, height, srs, coord):
         ''' Render a single tile, return a Response instance.
         '''

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -46,6 +46,9 @@ import Config
 _pathinfo_pat = re.compile(r'^/?(?P<l>\w.+)/(?P<z>\d+)/(?P<x>-?\d+)/(?P<y>-?\d+)\.(?P<e>\w+)$')
 _preview_pat = re.compile(r'^/?(?P<l>\w.+)/(preview\.html)?$')
 
+# symbol used to separate layers when specifying more than one layer
+_delimiter = ','
+
 def getTile(layer, coord, extension, ignore_cached=False):
     ''' Get a type string and tile binary for a given request layer tile.
     
@@ -142,9 +145,9 @@ def isValidLayer(layer, config):
     if not layer:
         return False
     if (layer not in config.layers):
-        if (layer.find(",") != -1):
+        if (layer.find(_delimiter) != -1):
             multi_providers = list(ll for ll in config.layers if hasattr(config.layers[ll].provider, 'names'))
-            for l in layer.split(","):
+            for l in layer.split(_delimiter):
                 if ((l not in config.layers) or (l in multi_providers)):
                     return False
             return True
@@ -191,12 +194,12 @@ def requestLayer(config, path_info):
     if not isValidLayer(layername, config):
         raise Core.KnownUnknown('"%s" is not a layer I know about. Here are some that I do know about: %s.' % (layername, ', '.join(sorted(config.layers.keys()))))
     
-    customLayer = layername.find(",")!=-1
+    customLayer = layername.find(_delimiter)!=-1
 
     if customLayer:
-        config.layers[","].provider(config.layers[","], **{'names': layername.split(",")})
+        config.layers[_delimiter].provider(config.layers[_delimiter], **{'names': layername.split(_delimiter)})
     
-    return config.layers[layername] if not customLayer else config.layers[","]
+    return config.layers[layername] if not customLayer else config.layers[_delimiter]
 
 def requestHandler(config_hint, path_info, query_string=None):
     """ Generate a mime-type and response body for a given request.

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -142,9 +142,9 @@ def isNotValidLayer(layer, config):
     if not layer:
         return True
     if (layer not in config.layers):
-        if (layer.find("+") != -1):
+        if (layer.find(",") != -1):
             multi_providers = list(ll for ll in config.layers if hasattr(config.layers[ll].provider, 'names'))
-            for l in layer.split("+"):
+            for l in layer.split(","):
                 if ((l not in config.layers) or (l in multi_providers)):
                     return True
             return False
@@ -191,12 +191,12 @@ def requestLayer(config, path_info):
     if isNotValidLayer(layername, config):
         raise Core.KnownUnknown('"%s" is not a layer I know about. Here are some that I do know about: %s.' % (layername, ', '.join(sorted(config.layers.keys()))))
     
-    customLayer = layername.find("+")!=-1
+    customLayer = layername.find(",")!=-1
 
     if customLayer:
-        config.layers["+"].provider(config.layers["+"], **{'names': layername.split("+")})
+        config.layers[","].provider(config.layers[","], **{'names': layername.split(",")})
     
-    return config.layers[layername] if not customLayer else config.layers["+"]
+    return config.layers[layername] if not customLayer else config.layers[","]
 
 def requestHandler(config_hint, path_info, query_string=None):
     """ Generate a mime-type and response body for a given request.

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -138,18 +138,18 @@ def mergePathInfo(layer, coord, extension):
     
     return '/%(layer)s/%(z)d/%(x)d/%(y)d.%(extension)s' % locals()
 
-def isNotValidLayer(layer, config):
+def isValidLayer(layer, config):
     if not layer:
-        return True
+        return False
     if (layer not in config.layers):
         if (layer.find(",") != -1):
             multi_providers = list(ll for ll in config.layers if hasattr(config.layers[ll].provider, 'names'))
             for l in layer.split(","):
                 if ((l not in config.layers) or (l in multi_providers)):
-                    return True
-            return False
-        return True
-    return False
+                    return False
+            return True
+        return False
+    return True
 
 def requestLayer(config, path_info):
     """ Return a Layer.
@@ -188,7 +188,7 @@ def requestLayer(config, path_info):
 
     layername = splitPathInfo(path_info)[0]
     
-    if isNotValidLayer(layername, config):
+    if not isValidLayer(layername, config):
         raise Core.KnownUnknown('"%s" is not a layer I know about. Here are some that I do know about: %s.' % (layername, ', '.join(sorted(config.layers.keys()))))
     
     customLayer = layername.find(",")!=-1
@@ -387,7 +387,7 @@ class WSGITileServer:
         # WSGI behavior is different from CGI behavior, because we may not want
         # to return a chatty rummy for likely-deployed WSGI vs. testing CGI.
         #
-        if isNotValidLayer(layer, self.config):
+        if not isValidLayer(layer, self.config):
             return self._response(start_response, 404)
 
         path_info = environ.get('PATH_INFO', None)

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -194,12 +194,12 @@ def requestLayer(config, path_info):
     if not isValidLayer(layername, config):
         raise Core.KnownUnknown('"%s" is not a layer I know about. Here are some that I do know about: %s.' % (layername, ', '.join(sorted(config.layers.keys()))))
     
-    customLayer = layername.find(_delimiter)!=-1
+    custom_layer = layername.find(_delimiter)!=-1
 
-    if customLayer:
+    if custom_layer:
         config.layers[config.custom_layer_name].provider(config.layers[config.custom_layer_name], **{'names': layername.split(_delimiter)})
     
-    return config.layers[layername] if not customLayer else config.layers[config.custom_layer_name]
+    return config.layers[layername] if not custom_layer else config.layers[config.custom_layer_name]
 
 def requestHandler(config_hint, path_info, query_string=None):
     """ Generate a mime-type and response body for a given request.

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -197,9 +197,9 @@ def requestLayer(config, path_info):
     customLayer = layername.find(_delimiter)!=-1
 
     if customLayer:
-        config.layers[_delimiter].provider(config.layers[_delimiter], **{'names': layername.split(_delimiter)})
+        config.layers[config.custom_layer_name].provider(config.layers[config.custom_layer_name], **{'names': layername.split(_delimiter)})
     
-    return config.layers[layername] if not customLayer else config.layers[_delimiter]
+    return config.layers[layername] if not customLayer else config.layers[config.custom_layer_name]
 
 def requestHandler(config_hint, path_info, query_string=None):
     """ Generate a mime-type and response body for a given request.

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -197,9 +197,11 @@ def requestLayer(config, path_info):
     custom_layer = layername.find(_delimiter)!=-1
 
     if custom_layer:
-        config.layers[config.custom_layer_name].provider(config.layers[config.custom_layer_name], **{'names': layername.split(_delimiter)})
-    
-    return config.layers[layername] if not custom_layer else config.layers[config.custom_layer_name]
+        config.layers[layername] = config.layers[config.custom_layer_name]
+        config.layers[layername].provider(config.layers[layername], **{'names': layername.split(_delimiter)})
+        del config.layers[config.custom_layer_name]
+
+    return config.layers[layername]
 
 def requestHandler(config_hint, path_info, query_string=None):
     """ Generate a mime-type and response body for a given request.


### PR DESCRIPTION
to handle requests that have a "," in the path (separating individual layers for ex: /buildings,places,pois/123/132.json)

Valid URLs:

```
/all/15/9660/12314.json //returns all the layers specified with this multiprovider 
/buildings/15/9660/12314.json //returns just buildings 
/pois,places/15/9660/12314.json //returns pois and places only 
/places,land-usages,buildings/15/9660/12314.json //returns places, land-usages and buildings
```

and these are obviously invalid and throws a 404

```
/foo/15/9660/12314.json //foo is not a valid layer
/buildings,pois,foo,places/15/9660/12314.json //foo is not a valid layer
/buildings,all,pois/15/9660/12314.json //this throws a 404 because all is a multiprovider 
```
