### PR TITLE
Vectiles constrain geom type

### DIFF
--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -472,5 +472,6 @@ def build_query(srid, subquery, subcolumns, bbox, tolerance, is_geo, is_clipped,
                 ) AS q
               WHERE ST_IsValid(q.__geometry__)
                 AND q.__geometry__ && %(bbox)s
-                AND ST_Intersects(q.__geometry__, %(bbox)s)''' \
+                AND ST_Intersects(q.__geometry__, %(bbox)s)
+                AND GeometryType(q.__geometry__) = GeometryType(%(geom)s)''' \
             % locals()

--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -473,5 +473,5 @@ def build_query(srid, subquery, subcolumns, bbox, tolerance, is_geo, is_clipped,
               WHERE ST_IsValid(q.__geometry__)
                 AND q.__geometry__ && %(bbox)s
                 AND ST_Intersects(q.__geometry__, %(bbox)s)
-                AND GeometryType(q.__geometry__) = GeometryType(%(geom)s)''' \
+                AND REPLACE(GeometryType(q.__geometry__), 'MULTI', '') = REPLACE(GeometryType(%(geom)s), 'MULTI', '')''' \
             % locals()


### PR DESCRIPTION
In some cases, postgis operations can cause the returned geometry type to be changed, e.g. a line can be clipped against a bounding box just on the very edge, turning it into a point. Clients typically expect the output geometry to be of the same type as the input, e.g. you want to be able to define a layer for rendering lines, and rely on getting back only lines. This is a small addition to the vector tile query to constrain geometries to the same type, but allows for MULTI geoms of the same underlying type to be mixed, e.g. a LINE is a valid output for a MULTILINE input, but a POINT is not.
