### PR TITLE
Resolve error on multiple layer requests

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -206,7 +206,6 @@ def requestLayer(config, path_info):
     if custom_layer:
         config.layers[layername] = config.layers[config.custom_layer_name]
         config.layers[layername].provider(config.layers[layername], **{'names': layername.split(_delimiter)})
-        del config.layers[config.custom_layer_name]
 
     return config.layers[layername]
 


### PR DESCRIPTION
In certain deployment models, the configuration is shared between
requests. The custom layer should not be removed or subsequent requests
will result in errors.
