### PR TITLE
fix seams on tile borders

### DIFF
--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -559,8 +559,9 @@ def build_query(srid, subquery, subcolumns, bounds, tolerance, is_geo, is_clippe
             geom = 'ST_MakeValid(ST_SimplifyPreserveTopology(%s, %.12f))' % (
                 geom, tolerance)
     
-        if is_clipped:
-            geom = 'ST_Intersection(%s, %s)' % (geom, bbox)
+        assert is_clipped, 'If simplify_before_intersect=True, ' \
+            'is_clipped should be True as well'
+        geom = 'ST_Intersection(%s, %s)' % (geom, bbox)
 
     else:
         # Cut tile, then simplify.

--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -544,7 +544,7 @@ def build_query(srid, subquery, subcolumns, bounds, tolerance, is_geo, is_clippe
             # entire geometry (just the small bits lying right outside the
             # desired tile).
 
-            simplification_padding = (bounds[3] - bounds[1]) * 0.1
+            simplification_padding = padding + (bounds[3] - bounds[1]) * 0.1
             simplification_bbox = (
                 'ST_MakeBox2D(ST_MakePoint(%.12f, %.12f), '
                 'ST_MakePoint(%.12f, %.12f))' % (


### PR DESCRIPTION
This PR fixes the seams that occasionally appear on tile borders, by simplifying geometries before cutting out a tile from them rather than the other way around. Copy-and-pasting my lengthy in-code documentation comment:

```
Special care must be taken when simplifying certain geometries (like those
in the earth/water layer) to prevent tile border "seams" from forming:
these occur when a geometry is split across multiple tiles (like a
continuous strip of land or body of water) and thus, for any such tile,
the part of that geometry inside of it lines up along one or more of its
edges. If there's any kind of fine geometric detail near one of these
edges, simplification might remove it in a way that makes the edge of the
geometry move off the edge of the tile. See this example of a tile
pre-simplification:
https://cloud.githubusercontent.com/assets/4467604/7937704/aef971b4-090f-11e5-91b9-d973ef98e5ef.png
and post-simplification:
https://cloud.githubusercontent.com/assets/4467604/7937705/b1129dc2-090f-11e5-9341-6893a6892a36.png
at which point a seam formed.

To get around this, for any given tile bounding box, we find the
contained/overlapping geometries and simplify them BEFORE
cutting out the precise tile bounding bbox (instead of cutting out the
tile and then simplifying everything inside of it, as we do with all of
the other layers).
```

This can be tweaked on a per-layer basis in the TileStache config, by specifying `"simplify_before_intersect": true` in the `kwargs` dictionaries.

related PRs: mapzen/vector-datasource#104, mapzen/tilequeue#16
