### PR TITLE
add hard dependency on Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,7 @@ def is_installed(name):
 
 
 requires = ['ModestMaps >=1.3.0', 'simplejson', 'Werkzeug',
-            'mapbox-vector-tile', 'StreetNames']
-
-# Soft dependency on PIL or Pillow
-if is_installed('Pillow') or sys.platform == 'win32':
-    requires.append('Pillow')
-else:
-    requires.append('PIL')
+            'mapbox-vector-tile', 'StreetNames', 'Pillow']
 
 
 setup(name='TileStache',


### PR DESCRIPTION
or atleast prefer Pillow over PIL as in TileStache/TileStache#196. The whole soft dependency thing in general causes problems with `pip install -r requirements.txt` because pip collects & then installs - in my case pip never finds my pillow require as it's not installed yet. Thank you.
