### PR TITLE
Add "intercut" post-processing function

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -366,3 +366,12 @@ def tags_name_i18n(shape, properties, fid, zoom):
             properties[alt_tag_name_candidate] = alt_tag_name_value
 
     return shape, properties, fid
+
+def intercut(feature_layers, base_layer, cutting_layer, attribute=None):
+    for feature_layer in feature_layers:
+        layer_datum = feature_layer['layer_datum']
+        layer_name = layer_datum['name']
+        if layer_name == base_layer:
+            return feature_layer
+
+    return None

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -383,7 +383,7 @@ def tags_name_i18n(shape, properties, fid, zoom):
 # layer to another so that they can be styled appropriately.
 #
 # returns a set of feature layers with the base layer
-# replaced by a cut one, or None if there's an error.
+# replaced by a cut one.
 def intercut(feature_layers, base_layer, cutting_layer, attribute=None, target_attribute=None):
     base = None
     cutting = None
@@ -408,10 +408,8 @@ def intercut(feature_layers, base_layer, cutting_layer, attribute=None, target_a
         elif layer_name == cutting_layer:
             cutting = feature_layer
 
-    # didn't find one or other layer - what's the appropriate
-    # thing to do here, raise an error?
-    if base is None or cutting is None:
-        return None
+    assert base is not None and cutting is not None, \
+        'could not find base or cutting layer in intercut. config error'
 
     base_features = base['features']
     cutting_features = cutting['features']
@@ -423,11 +421,11 @@ def intercut(feature_layers, base_layer, cutting_layer, attribute=None, target_a
     for cutting_feature in cutting_features:
         cutting_shape, cutting_props, cutting_id = cutting_feature
         cutting_attr = None
-        if attribute is not None and attribute in cutting_props:
-            cutting_attr = cutting_props[attribute]
+        if attribute is not None:
+            cutting_attr = cutting_props.get(attribute)
 
         new_features = []
-        for index, base_feature in enumerate(base_features):
+        for base_feature in base_features:
             base_shape, base_props, base_id = base_feature
 
             if base_shape.intersects(cutting_shape):

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -462,8 +462,15 @@ def intercut(feature_layers, base_layer, cutting_layer,
         elif layer_name == cutting_layer:
             cutting = feature_layer
 
-    assert base is not None and cutting is not None, \
-        'could not find base or cutting layer in intercut. config error'
+    # base or cutting layer not available. this could happen
+    # because of a config problem, in which case you'd want
+    # it to be reported. but also can happen when the client
+    # selects a subset of layers which don't include either
+    # the base or the cutting layer. then it's not an error.
+    # the interesting case is when they select the base but
+    # not the cutting layer...
+    if base is None or cutting is None:
+        return None
 
     # just skip the whole thing if there's no attribute to
     # cut with.

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -437,7 +437,7 @@ def _make_cut_index(features, attrs, attribute):
 # returns a feature layer which is the base layer cut by the
 # cutting layer.
 def intercut(feature_layers, base_layer, cutting_layer,
-             attribute=None, target_attribute=None,
+             attribute, target_attribute=None,
              cutting_attrs=None):
     base = None
     cutting = None
@@ -472,10 +472,12 @@ def intercut(feature_layers, base_layer, cutting_layer,
     if base is None or cutting is None:
         return None
 
-    # just skip the whole thing if there's no attribute to
-    # cut with.
-    if attribute is None:
-        return base
+    # sanity check on the availability of the cutting
+    # attribute.
+    assert attribute is not None, \
+        'Parameter attribute to intercut was None, but ' + \
+        'should have been an attribute name. Perhaps check ' + \
+        'your configuration file and queries.'
 
     base_features = base['features']
     cutting_features = cutting['features']


### PR DESCRIPTION
This is part of a potential fix for https://github.com/mapzen/vector-datasource/issues/136, and implements the algorithm for splitting up features in one layer based on features in another, and transferring attributes across based on whether the split part is inside or outside the feature in the other layer.

The code to actually use this function is split between the tilequeue and tileserver repos, so see below for the cross-links to those PRs.
