### PR TITLE
Sort places by kind then population

### DIFF
--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -36,7 +36,7 @@ def _by_population(feature):
     return population
 
 
-def _sort_by_place_kind_then_population(features):
+def _sort_by_scalerank_then_population(features):
     features.sort(key=_by_population, reverse=True)
     features.sort(key=_by_scalerank)
     return features
@@ -55,7 +55,7 @@ def landuse(features, zoom):
 
 
 def places(features, zoom):
-    return _sort_by_place_kind_then_population(features)
+    return _sort_by_scalerank_then_population(features)
 
 
 def pois(features, zoom):

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -1,3 +1,5 @@
+from transform import to_float
+
 # sort functions to apply to features
 
 
@@ -32,12 +34,11 @@ def _by_scalerank(feature):
 def _by_population(feature):
     wkb, properties, fid = feature
     default_value = -1000
-    population_str = properties.get('population', default_value)
-    try:
-        population = int(population_str)
-    except ValueError:
-        population = default_value
-    return population
+    population_flt = to_float(properties.get('population', default_value))
+    if population_flt is not None:
+        return int(population_flt)
+    else:
+        return default_value
 
 
 def _sort_by_scalerank_then_population(features):

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -36,9 +36,89 @@ def _by_population(feature):
     return population
 
 
-def _sort_by_scalerank_then_population(features):
+# place kinds, as used by OSM and NE, mapped to their rough
+# priority values so that places can be sorted into a decent
+# enough draw order on the server.
+_place_sort_order = {
+    # zoom >= 13
+    'locality': 1302,
+    'isolated_dwelling': 1301,
+    'farm': 1300,
+
+    # zoom >= 12
+    'hamlet': 1201,
+    'neighbourhood': 1200,
+
+    # zoom >= 11
+    'village': 1100,
+
+    # zoom >= 10
+    'suburb': 1002,
+    'quarter': 1001,
+    'borough': 1000,
+
+    # zoom >= 8
+    # note: these have 50 added, so that some can be
+    # taken away for capitals & state capitals.
+    'town': 851,
+    'Populated place': 851,
+    'city': 850,
+    'Admin-0 capital': 850,
+    'Admin-1 capital': 850,
+
+    # zoom >= 4
+    'province': 401,
+    'state': 400,
+
+    # zoom >= 3
+    'sea': 300,
+
+    # always on
+    'country': 102,
+    'ocean': 101,
+    'continent': 100,
+
+# these have a relatively significant level of use in
+# OSM, but aren't currently selected by the query.
+# perhaps we should be using these too?
+#    'island': 0,
+#    'islet': 0,
+#    'county': 0,
+#    'city_block': 0,
+#    'region': 0,
+#    'municipality': 0,
+#    'subdistrict': 0,
+#    'township': 0,
+#    'archipelago': 0,
+#    'country': 0,
+#    'district': 0,
+#    'block': 0,
+#    'department': 0,
+}
+
+
+def _by_place_kind(feature):
+    wkb, properties, fid = feature
+
+    kind = properties.get('kind')
+    state_capital = properties.get('state_capital')
+    capital = properties.get('capital')
+
+    order = _place_sort_order.get(kind, 9999)
+
+    # hmm... seems like a nasty little hack to get
+    # state capital status to be taken into account...
+    if capital == 'yes':
+        order -= 50
+    elif state_capital == 'yes':
+        order -= 20
+
+    return order
+
+
+def _sort_by_place_kind_then_population(features):
     features.sort(key=_by_population, reverse=True)
-    features.sort(key=_by_scalerank)
+    features.sort(key=_by_place_kind)
     return features
 
 
@@ -55,7 +135,7 @@ def landuse(features, zoom):
 
 
 def places(features, zoom):
-    return _sort_by_scalerank_then_population(features)
+    return _sort_by_place_kind_then_population(features)
 
 
 def pois(features, zoom):

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -31,8 +31,12 @@ def _by_scalerank(feature):
 
 def _by_population(feature):
     wkb, properties, fid = feature
-    value_for_none = -1000
-    population = int(properties.get('population', value_for_none))
+    default_value = -1000
+    population_str = properties.get('population', default_value)
+    try:
+        population = int(population_str)
+    except ValueError:
+        population = default_value
     return population
 
 

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -32,7 +32,7 @@ def _by_scalerank(feature):
 def _by_population(feature):
     wkb, properties, fid = feature
     value_for_none = -1000
-    population = properties.get('population', value_for_none)
+    population = int(properties.get('population', value_for_none))
     return population
 
 

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -36,89 +36,9 @@ def _by_population(feature):
     return population
 
 
-# place kinds, as used by OSM and NE, mapped to their rough
-# priority values so that places can be sorted into a decent
-# enough draw order on the server.
-_place_sort_order = {
-    # zoom >= 13
-    'locality': 1302,
-    'isolated_dwelling': 1301,
-    'farm': 1300,
-
-    # zoom >= 12
-    'hamlet': 1201,
-    'neighbourhood': 1200,
-
-    # zoom >= 11
-    'village': 1100,
-
-    # zoom >= 10
-    'suburb': 1002,
-    'quarter': 1001,
-    'borough': 1000,
-
-    # zoom >= 8
-    # note: these have 50 added, so that some can be
-    # taken away for capitals & state capitals.
-    'town': 851,
-    'Populated place': 851,
-    'city': 850,
-    'Admin-0 capital': 850,
-    'Admin-1 capital': 850,
-
-    # zoom >= 4
-    'province': 401,
-    'state': 400,
-
-    # zoom >= 3
-    'sea': 300,
-
-    # always on
-    'country': 102,
-    'ocean': 101,
-    'continent': 100,
-
-# these have a relatively significant level of use in
-# OSM, but aren't currently selected by the query.
-# perhaps we should be using these too?
-#    'island': 0,
-#    'islet': 0,
-#    'county': 0,
-#    'city_block': 0,
-#    'region': 0,
-#    'municipality': 0,
-#    'subdistrict': 0,
-#    'township': 0,
-#    'archipelago': 0,
-#    'country': 0,
-#    'district': 0,
-#    'block': 0,
-#    'department': 0,
-}
-
-
-def _by_place_kind(feature):
-    wkb, properties, fid = feature
-
-    kind = properties.get('kind')
-    state_capital = properties.get('state_capital')
-    capital = properties.get('capital')
-
-    order = _place_sort_order.get(kind, 9999)
-
-    # hmm... seems like a nasty little hack to get
-    # state capital status to be taken into account...
-    if capital == 'yes':
-        order -= 50
-    elif state_capital == 'yes':
-        order -= 20
-
-    return order
-
-
 def _sort_by_place_kind_then_population(features):
     features.sort(key=_by_population, reverse=True)
-    features.sort(key=_by_place_kind)
+    features.sort(key=_by_scalerank)
     return features
 
 

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -7,7 +7,10 @@ from shapely.strtree import STRtree
 import re
 
 
-def _to_float(x):
+# attempts to convert x to a floating point value,
+# first removing some common punctuation. returns
+# None if conversion failed.
+def to_float(x):
     if x is None:
         return None
     # normalize punctuation

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -29,7 +29,7 @@ def _to_float_meters(x):
     if x is None:
         return None
 
-    as_float = _to_float(x)
+    as_float = to_float(x)
     if as_float is not None:
         return as_float
 
@@ -38,7 +38,7 @@ def _to_float_meters(x):
 
     # try explicit meters suffix
     if x.endswith(' m'):
-        meters_as_float = _to_float(x[:-2])
+        meters_as_float = to_float(x[:-2])
         if meters_as_float is not None:
             return meters_as_float
 
@@ -47,8 +47,8 @@ def _to_float_meters(x):
     if feet_match is not None:
         feet = feet_match.group(1)
         inches = feet_match.group(2)
-        feet_as_float = _to_float(feet)
-        inches_as_float = _to_float(inches)
+        feet_as_float = to_float(feet)
+        inches_as_float = to_float(inches)
 
         total_inches = 0.0
         parsed_feet_or_inches = False
@@ -65,7 +65,7 @@ def _to_float_meters(x):
     # try and match the first number that can be parsed
     for number_match in number_pattern.finditer(x):
         potential_number = number_match.group(1)
-        as_float = _to_float(potential_number)
+        as_float = to_float(potential_number)
         if as_float is not None:
             return as_float
 
@@ -265,7 +265,7 @@ def road_sort_key(shape, properties, fid, zoom):
         # Explicit layer is clipped to [-5, 5] range
         layer = properties.get('layer')
         if layer:
-            layer_float = _to_float(layer)
+            layer_float = to_float(layer)
             if layer_float is not None:
                 layer_float = max(min(layer_float, 5), -5)
                 # The range of values from above is [5, 34]


### PR DESCRIPTION
Refs mapzen/vector-datasource#168.

Instead of sorting by scalerank, assigns a numeric value to the place kinds that can come from OSM or NE and uses that to order the results. Also, fixes the population comparator to return an int, as previously it was comparing strings.
