### PR TITLE
Add water boundaries post-processing function.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -673,6 +673,7 @@ def exterior_boundaries(feature_layers, base_layer,
 
         if layer_name == base_layer:
             layer = feature_layer
+            break
 
     # if we failed to find the base layer then it's
     # possible the user just didn't ask for it, so return


### PR DESCRIPTION
This adds a function which post-processes a base layer to create a new layer containing the boundaries of all the polygons in the base layer, each having been trimmed against the other polygons in the layer such that no part of the boundary is within any other polygon.

This requires mapzen/tilequeue#25 and refs mapzen/vector-datasource#140, and I'll put a pic there of how it looks.

@rmarianski could you review, please?
