### PR TITLE
Fix a bug where we were treating an int as a str.

### DIFF
--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -34,7 +34,7 @@ def _by_scalerank(feature):
 def _by_population(feature):
     wkb, properties, fid = feature
     default_value = -1000
-    population_flt = to_float(properties.get('population', default_value))
+    population_flt = to_float(properties.get('population'))
     if population_flt is not None:
         return int(population_flt)
     else:


### PR DESCRIPTION
The `to_float` function expects a `str` or None, but we were passing it an `int`. The function then tries to replace ';' and ',', but that's not a valid operation on an `int`. Instead, where the parameter is missing, we'll default to None which is handled by `to_float` and apply the `int` default afterwards.
