### PR TITLE
Fix water boundary bug.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -971,8 +971,8 @@ def exterior_boundaries(feature_layers, zoom,
     # create an index so that we can efficiently find the
     # polygons intersecting the 'current' one. Note that
     # we're only interested in intersecting with other
-    # areal features, and that intersecting with lines can
-    # give some unexpected results.
+    # polygonal features, and that intersecting with lines
+    # can give some unexpected results.
     indexable_features = list()
     for shape, props, fid in features:
         if shape.geom_type in ('Polygon', 'MultiPolygon'):

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -969,8 +969,15 @@ def exterior_boundaries(feature_layers, zoom,
     features = layer['features']
 
     # create an index so that we can efficiently find the
-    # polygons intersecting the 'current' one.
-    index = STRtree([f[0] for f in features])
+    # polygons intersecting the 'current' one. Note that
+    # we're only interested in intersecting with other
+    # areal features, and that intersecting with lines can
+    # give some unexpected results.
+    indexable_features = list()
+    for shape, props, fid in features:
+        if shape.geom_type in ('Polygon', 'MultiPolygon'):
+            indexable_features.append(shape)
+    index = STRtree(indexable_features)
 
     new_features = list()
     # loop through all the polygons, taking the boundary


### PR DESCRIPTION
Only index areal geometry types for differencing with water boundaries. This fixes the bug shown here:

![water_boundary_bug_before](https://cloud.githubusercontent.com/assets/271360/9878643/a7a72e34-5bbb-11e5-9482-1ca7a3cb5486.png)

The issue appears to be related to numerical precision at first, but further investigation showed that it only occurred on one "side" of the boundary (i.e: given polygons A & B, `boundary(A).difference(B)` was fine, but `boundary(B).difference(A)` showed the bug) and it only occurred when the boundary had been first been differenced with the linestring of the river centerline. Given we're not interested in differencing with centerlines anyway, it seemed best to simply discard that from the shapes we cut against. This gives:

![water_boundary_bug_after](https://cloud.githubusercontent.com/assets/271360/9878700/f898c546-5bbb-11e5-9103-e27ad1aa7e51.png)

Refs mapzen/vector-datasource#209, where I first saw this bug.
