### PR TITLE
Preserve left/right name translations in filter pipeline

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -374,7 +374,9 @@ def tags_name_i18n(shape, properties, fid, zoom):
         if (k.startswith('name:') and v != name or
                 k.startswith('alt_name:') and v != name or
                 k.startswith('alt_name_') and v != name or
-                k.startswith('old_name:') and v != name):
+                k.startswith('old_name:') and v != name or
+                k.startswith('left:name:') and v != name or
+                k.startswith('right:name:') and v != name):
             properties[k] = v
 
     for alt_tag_name_candidate in tag_name_alternates:


### PR DESCRIPTION
Refs mapzen/vector-datasource#180.

The queries put the left name translations under keys "left:name:..." and similar for the right translations. We want these to survive into the output to be used for the appropriate labels.

@rmarianski could you review, please?
