### PR TITLE
Fix for missing roads regression.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -473,8 +473,8 @@ _GEOMETRY_DIMENSIONS = {
 #   4: contains a polygon / two-dimensional object
 def _geom_dimensions(g):
     dim = _GEOMETRY_DIMENSIONS.get(g.geom_type)
-    assert dim, "Unknown geometry type %s in " + \
-        "transform._geom_dimensions." % \
+    assert dim is not None, "Unknown geometry type " + \
+        "%s in transform._geom_dimensions." % \
         repr(g.geom_type)
 
     # recurse for geometry collections to find the true
@@ -567,21 +567,21 @@ class _Cutter:
     # same as the original, or we're not trying to keep the
     # same type.
     def _add(self, shape, props, fid, original_geom_dim):
+        # don't add empty shapes, they're completely
+        # useless.
+        if shape.is_empty:
+            return
+
         # use a custom dimension measurement here, as it
         # turns out shapely geometry objects don't always
         # form a hierarchy that's usable with isinstance.
         shape_dim = _geom_dimensions(shape)
 
-        # don't add empty shapes, they're completely
-        # useless.
-        if shape.is_empty:
-            pass
-
         # add the shape as-is unless we're trying to keep
         # the geometry type or the geometry dimension is
         # identical.
-        elif not self.keep_geom_type or \
-             shape_dim == original_geom_dim:
+        if not self.keep_geom_type or \
+           shape_dim == original_geom_dim:
             self.new_features.append((shape, props, fid))
 
 

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -505,11 +505,11 @@ class _Cutter:
                         shape, props, fid, cutting_shape,
                         cutting_attr, original_geom_type)
 
-            # if there's no geometry left outside the
-            # shape, then we can exit the loop early, as
-            # nothing else will intersect.
-            if shape.is_empty:
-                break
+                # if there's no geometry left outside the
+                # shape, then we can exit the function
+                # early, as nothing else will intersect.
+                if shape.is_empty:
+                    return
 
         # if there's still geometry left outside, then it
         # keeps the old, unaltered properties.


### PR DESCRIPTION
This fixes the base cause of mapzen/vector-datasource#204: Objects were being returned from the intercut algorithm which were MultiLineStrings, but which were not being detected as such in the test for `Multi*` geometries which was using `isinstance`. This led to some road segments being dropped from the tile.

@rmarianski could you review, please?
