### PR TITLE
Don't recurse infinitely

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -483,7 +483,7 @@ def _geom_dimensions(g):
     # dimensionality of the geometry.
     if dim == 0:
         for part in g.geoms:
-            dim = dim | _geom_dimensions(g)
+            dim = dim | _geom_dimensions(part)
 
     return dim
 


### PR DESCRIPTION
Ooops. Recurse on geometry `part`, rather than on the original geometry `g`. Stops infinite recursion.

@rmarianski could you review, please?
