### PR TITLE
Add ferry routes

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -133,6 +133,9 @@ def _road_kind(properties):
     railway = properties.get('railway')
     if railway in road_kind_rail:
         return 'rail'
+    route = properties.get('route')
+    if route == 'ferry':
+        return 'ferry'
     return 'minor_road'
 
 


### PR DESCRIPTION
This is signalled in OSM data by a `route=ferry` tag, so that gets assigned to the kind.

Connects to mapzen/vector-datasource#187.

@rmarianski could you review, please?
