### PR TITLE
Set kind to `aboriginal_lands` for first nations state boundaries.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -368,6 +368,15 @@ def boundary_kind(shape, properties, fid, zoom):
     kind = properties.get('kind')
     if kind:
         return shape, properties, fid
+
+    # if the boundary is tagged as being that of a first nations
+    # state then skip the rest of the kind logic, regardless of
+    # the admin_level (see mapzen/vector-datasource#284).
+    boundary_type = properties.get('boundary_type')
+    if boundary_type == 'aboriginal_lands':
+        properties['kind'] = 'aboriginal_lands'
+        return shape, properties, fid
+
     admin_level_str = properties.get('admin_level')
     if admin_level_str is None:
         return shape, properties, fid
@@ -378,6 +387,13 @@ def boundary_kind(shape, properties, fid, zoom):
     kind = boundary_admin_level_mapping.get(admin_level_int)
     if kind:
         properties['kind'] = kind
+    return shape, properties, fid
+
+
+def boundary_trim_properties(shape, properties, fid, zoom):
+    properties = _remove_properties(
+        properties,
+        'boundary_type')
     return shape, properties, fid
 
 


### PR DESCRIPTION
Connects to mapzen/vector-datasource#284.

Modifies the boundary kind logic to set it to `aboriginal_lands` where that is the `boundary:type`. This is the case for [the Hoopa Valley Tribe boundary](http://www.openstreetmap.org/way/174550914), which is the boundary of interest in mapzen/vector-datasource#284. It was appearing because it is tagged as an `admin_level=4` boundary, i.e: a state-level boundary.

@rmarianski could you review, please?
