### PR TITLE
Update label feature generation behavior

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1483,6 +1483,14 @@ def generate_label_features(
         if shape.geom_type not in ('Polygon', 'MultiPolygon'):
             continue
 
+        # Additionally, the feature needs to have a name or a sport
+        # tag, oherwise it's not really useful for labelling purposes
+        name = properties.get('name')
+        if not name:
+            sport = properties.get('sport')
+            if not sport:
+                continue
+
         # shapely also has a function `representative_point` which we
         # might want to consider using here
         label_centroid = shape.centroid

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1491,13 +1491,13 @@ def generate_label_features(
             if not sport:
                 continue
 
-        # shapely also has a function `representative_point` which we
-        # might want to consider using here
-        label_centroid = shape.centroid
+        label_point = shape.representative_point()
+
         label_properties = properties.copy()
         if label_property_name:
             label_properties[label_property_name] = label_property_value
-        label_feature = label_centroid, label_properties, fid
+
+        label_feature = label_point, label_properties, fid
 
         # if we're adding these features to a new layer, don't add the
         # original features


### PR DESCRIPTION
- Use representative_point instead of centroid
- Only include labels with name or sport tags

Refs https://github.com/mapzen/tilequeue/issues/21 and https://github.com/mapzen/vector-datasource/issues/221
