### PR TITLE
Sort out generated features for landuse, buildings & POIs

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1773,7 +1773,8 @@ def drop_features_where(
         geom_types=None):
     """
     Drops some features entirely when they have a property
-    named `property_name` and its value is true. Also can
+    named `property_name` and its value is true. Note that it
+    must be identically True, not just truthy. Also can
     drop the property if `drop_property` is truthy. If
     `geom_types` is present and not None, then only types in
     that list are considered for dropping.
@@ -1801,16 +1802,21 @@ def drop_features_where(
             geom_types is None or \
             shape.geom_type in geom_types
 
-        val = None
+        # figure out what to do with the property - do we
+        # want to drop it, or just fetch it?
+        func = properties.get
         if drop_property:
-            val = properties.pop(property_name, None)
-        else:
-            val = properties.get(property_name)
+            func = properties.drop
 
+        val = func(property_name, None)
+
+        # skip (i.e: drop) the geometry if the value is
+        # true and it's the geometry type we want.
         if val == True and matches_geom_type:
-            pass
-        else:
-            new_features.append((shape, properties, fid))
+            continue
+
+        # default case is to keep the feature
+        new_features.append((shape, properties, fid))
 
     layer['features'] = new_features
     return layer

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1696,6 +1696,11 @@ def generate_address_points(
     for feature in layer['features']:
         shape, properties, fid = feature
 
+        # We only want to create address points for polygonal
+        # buildings with address tags.
+        if shape.geom_type not in ('Polygon', 'MultiPolygon'):
+            continue
+
         addr_housenumber = properties.get('addr_housenumber')
 
         # consider it an address if the name of the building
@@ -1710,11 +1715,9 @@ def generate_address_points(
             elif name == addr_housenumber:
                 properties.pop('name')
 
-        # We only want to create address points for polygonal
-        # buildings with address tags.
-        if shape.geom_type not in ('Polygon', 'MultiPolygon') or \
-           addr_housenumber is None:
-            # keep the feature as-is, no modifications.
+        # if there's no address, then keep the feature as-is,
+        # no modifications.
+        if addr_housenumber is None:
             continue
 
         label_point = shape.representative_point()

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1832,7 +1832,7 @@ def remove_zero_area(shape, properties, fid, zoom):
     # try to parse a string if the area has been sent as a
     # string. it should come through as a float, though,
     # since postgres treats it as a real.
-    if isinstance(area, str):
+    if isinstance(area, (str, unicode)):
         area = to_float(area)
 
     if area is not None:

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1571,7 +1571,7 @@ def generate_address_points(
     building.
     """
 
-    assert source_layer, 'generate_label_features: missing source_layer'
+    assert source_layer, 'generate_address_points: missing source_layer'
 
     if zoom < start_zoom:
         return None
@@ -1587,6 +1587,18 @@ def generate_address_points(
         # remove address tags on the original polygon,
         # we only want them on the address point.
         addr_housenumber = properties.pop('addr_housenumber', None)
+
+        # also consider it an address if the name of
+        # the building is just a number.
+        name = properties.get('name')
+        if name is not None and re.match('^[0-9-]+$', name):
+            if addr_housenumber is None:
+                addr_housenumber = properties.pop('name')
+
+            # and also suppress the name if it's the same as
+            # the address.
+            elif name == addr_housenumber:
+                properties.pop('name')
 
         # We only want to create address points for polygonal
         # buildings with address tags.

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1564,7 +1564,7 @@ def generate_label_features(
 
 
 def generate_address_points(
-        feature_layers, zoom, source_layer=None):
+        feature_layers, zoom, source_layer=None, start_zoom=0):
     """
     Generates address points from building polygons where there is an
     addr:housenumber tag on the building. Removes those tags from the
@@ -1572,6 +1572,9 @@ def generate_address_points(
     """
 
     assert source_layer, 'generate_label_features: missing source_layer'
+
+    if zoom < start_zoom:
+        return None
 
     layer = _find_layer(feature_layers, source_layer)
     if layer is None:

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -643,7 +643,7 @@ def _filter_geom_types(shape, keep_dim):
         constructor = MultiPolygon
 
     else:
-        raise Exception("Unknown dimension %d in _filter_geom_types" % keep_dim)
+        raise ValueError("Unknown dimension %d in _filter_geom_types" % keep_dim)
 
     if len(parts) == 0:
         return constructor()

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1617,7 +1617,7 @@ def generate_address_points(
         if source is not None:
             label_properties['source'] = source
 
-        addr_street = properties.pop('addr_street', None)
+        addr_street = properties.get('addr_street')
         if addr_street is not None:
             label_properties['addr_street'] = addr_street
 

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1605,10 +1605,6 @@ def generate_address_points(
             # keep the feature as-is, no modifications.
             continue
 
-        # remove address tags on the original polygon,
-        # we only want them on the address point.
-        properties.pop('addr_housenumber')
-
         label_point = shape.representative_point()
 
         # we're only interested in a very few properties for

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1806,3 +1806,33 @@ def drop_features_where(
 
     layer['features'] = new_features
     return layer
+
+
+def remove_zero_area(shape, properties, fid, zoom):
+    """
+    All features get a numeric area tag, but for points this
+    is zero. The area probably isn't exactly zero, so it's
+    probably less confusing to just remove the tag to show
+    that the value is probably closer to "unspecified".
+    """
+
+    # remove the property if it's present. we _only_ want
+    # to replace it if it matches the positive, float
+    # criteria.
+    area = properties.pop("area", None)
+
+    # try to parse a string if the area has been sent as a
+    # string. it should come through as a float, though,
+    # since postgres treats it as a real.
+    if isinstance(area, str):
+        area = to_float(area)
+
+    if area is not None:
+        # cast to integer to match what we do for polygons.
+        # also the fractional parts of a sq.m are just
+        # noise really.
+        area = int(area)
+        if area > 0:
+            properties['area'] = area
+
+    return shape, properties, fid

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -631,17 +631,28 @@ def _filter_geom_types(shape, keep_dim):
         if _geom_dimensions(g) == keep_dim:
             parts.append(g)
 
+    # figure out how to construct a multi-geometry of the
+    # dimension wanted.
+    if keep_dim == _POINT_DIMENSION:
+        constructor = MultiPoint
+
+    elif keep_dim == _LINE_DIMENSION:
+        constructor = MultiLineString
+
+    elif keep_dim == _POLYGON_DIMENSION:
+        constructor = MultiPolygon
+
+    else:
+        raise Exception("Unknown dimension %d in _filter_geom_types" % keep_dim)
+
     if len(parts) == 0:
-        # the only way we can signal an empty geometry, as
-        # MultiPoint([]) throws an exception.
-        return GeometryCollection()
+        return constructor()
 
     elif len(parts) == 1:
         # return the singular geometry
         return parts[0]
 
     else:
-        # try to make a multi-geometry of the desirect type
         if keep_dim == _POINT_DIMENSION:
             # not sure why the MultiPoint constructor wants
             # its coordinates differently from MultiPolygon
@@ -651,14 +662,8 @@ def _filter_geom_types(shape, keep_dim):
                 coords.extend(p.coords)
             return MultiPoint(coords)
 
-        elif keep_dim == _LINE_DIMENSION:
-            return MultiLineString(parts)
-
-        elif keep_dim == _POLYGON_DIMENSION:
-            return MultiPolygon(parts)
-
         else:
-            raise Exception("Unknown dimension %d in _filter_geom_types" % keep_dim)
+            return constructor(parts)
 
 
 # creates a list of indexes, each one for a different cut

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1584,12 +1584,10 @@ def generate_address_points(
     for feature in layer['features']:
         shape, properties, fid = feature
 
-        # remove address tags on the original polygon,
-        # we only want them on the address point.
-        addr_housenumber = properties.pop('addr_housenumber', None)
+        addr_housenumber = properties.get('addr_housenumber')
 
-        # also consider it an address if the name of
-        # the building is just a number.
+        # consider it an address if the name of the building
+        # is just a number.
         name = properties.get('name')
         if name is not None and re.match('^[0-9-]+$', name):
             if addr_housenumber is None:
@@ -1607,6 +1605,10 @@ def generate_address_points(
             # keep the feature as-is, no modifications.
             continue
 
+        # remove address tags on the original polygon,
+        # we only want them on the address point.
+        properties.pop('addr_housenumber')
+
         label_point = shape.representative_point()
 
         # we're only interested in a very few properties for
@@ -1622,6 +1624,10 @@ def generate_address_points(
         addr_street = properties.pop('addr_street', None)
         if addr_street is not None:
             label_properties['addr_street'] = addr_street
+
+        oid = properties.get('id')
+        if oid is not None:
+            label_properties['id'] = oid
 
         label_feature = label_point, label_properties, fid
 


### PR DESCRIPTION
This PR contains:
- Updates for buildings: we now have a "purely building" kind and aren't pulling in extra properties from amenities. If these need labelling, then that now should come from the POIs layer directly.
- Civic Center Park was showing some weirdness with the footpath around its boundary. This turned out to be due to mixed geometry types in the intercut results. The new flattening and filtering functions for geometries ensure that we get the types of geometries expected from the cut, but also don't throw away bits with different geometries.
- Added a function to generate address points from buildings. These are different from label points (although the label points also have addresses). We get some address points directly from points in the table, but this extracts representative points for buildings too, and normalises the building name to an address where it's purely numeric (which seems quite common).
- Added a "drop features where" post-processing function which allows dropping landuse polygons which would be duplicated by building polygons and we want to keep the building over the landuse. The reason we don't just not select it is that we still want the representative point for labelling.

Connects to mapzen/vector-datasource#201.

@rmarianski could you review, please?
