### PR TITLE
Prioritise subway station features.

### DIFF
--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -1,4 +1,4 @@
-from transform import to_float
+from util import to_float
 
 # sort functions to apply to features
 

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -47,6 +47,23 @@ def _sort_by_scalerank_then_population(features):
     return features
 
 
+def _by_subway_lines(feature):
+    wkb, props, fid = feature
+
+    num_lines = 0
+    subway_lines = props.get('subway_lines')
+    if subway_lines is not None:
+        num_lines = len(subway_lines)
+
+    return num_lines
+
+
+def _sort_by_subway_lines_then_feature_id(features):
+    features.sort(key=_by_feature_id)
+    features.sort(key=_by_subway_lines, reverse=True)
+    return features
+
+
 def buildings(features, zoom):
     return _sort_by_area_then_id(features)
 
@@ -64,7 +81,7 @@ def places(features, zoom):
 
 
 def pois(features, zoom):
-    return _sort_features_by_key(features, _by_feature_id)
+    return _sort_by_subway_lines_then_feature_id(features)
 
 
 def roads(features, zoom):

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -2006,20 +2006,20 @@ def normalize_and_merge_duplicate_stations(
                 seen_props = new_features[seen_idx][1]
 
                 # make sure lines are unique
-                seen_subway_lines = set(seen_props['subway_lines'])
-                subway_lines = set(subway_lines)
-                subway_lines.update(seen_subway_lines)
-
-                seen_props['subway_lines'] = list(subway_lines)
+                unique_subway_lines = set(subway_lines) & \
+                    set(seen_props['subway_lines'])
+                seen_props['subway_lines'] = list(unique_subway_lines)
 
         else:
             # not a station, or name is missing - we can't
             # de-dup these.
             new_features.append(feature)
 
-    # need to re-sort: removing duplicates would have changed
-    # the number of lines for each station.
-    sort_pois(new_features, zoom)
+    # might need to re-sort, if we merged any stations:
+    # removing duplicates would have changed the number
+    # of lines for each station.
+    if seen_stations:
+        sort_pois(new_features, zoom)
 
     layer['features'] = new_features
     return layer
@@ -2067,8 +2067,9 @@ def keep_n_features(
         return None
 
     # we probably don't want to do this at higher zooms (e.g: 17 &
-    # 18), even if there are a bunch of stations very close
-    # together.
+    # 18), even if there are a bunch of features in the tile, as
+    # we use the high-zoom tiles for overzooming to 20+, and we'd
+    # eventually expect to see _everything_.
     if end_zoom is not None and zoom > end_zoom:
         return None
 

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -10,21 +10,8 @@ from shapely.geometry.multipoint import MultiPoint
 from shapely.geometry.multilinestring import MultiLineString
 from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.collection import GeometryCollection
+from util import to_float
 import re
-
-
-# attempts to convert x to a floating point value,
-# first removing some common punctuation. returns
-# None if conversion failed.
-def to_float(x):
-    if x is None:
-        return None
-    # normalize punctuation
-    x = x.replace(';', '.').replace(',', '.')
-    try:
-        return float(x)
-    except ValueError:
-        return None
 
 
 feet_pattern = re.compile('([+-]?[0-9.]+)\'(?: *([+-]?[0-9.]+)")?')

--- a/TileStache/Goodies/VecTiles/util.py
+++ b/TileStache/Goodies/VecTiles/util.py
@@ -1,0 +1,12 @@
+# attempts to convert x to a floating point value,
+# first removing some common punctuation. returns
+# None if conversion failed.
+def to_float(x):
+    if x is None:
+        return None
+    # normalize punctuation
+    x = x.replace(';', '.').replace(',', '.')
+    try:
+        return float(x)
+    except ValueError:
+        return None


### PR DESCRIPTION
In some places with dense public transit infrastructure (e.g: NYC) we are displaying too many stations at zoom 13/14 and need some way to select which are the important ones.

This PR modifies the POI sort function so that it sorts POIs by the number of subway lines they're part of. This will be zero for most POIs, which aren't stations, and so is a no-op for those kinds.

This PR also adds 3 new post-process functions:
1. `normalize_and_merge_duplicate_stations` parses the names of stations, which are frequently of the form "Station Name (A, B, C)" where "A, B, C" are the lines that it is on. The query additionally pulls in lines found from looking at the OSM relations, but these are frequently missing or mis-tagged. Parsing them from the name allows us a backup and leaves the name in a better state for merging. This function also merges stations by name, taking the union of all the lines that they're on. This function also re-sorts, as the merging process may have altered the number of lines that a station is part of.
2. `keep_n_features` keeps the first N features which match a particular type. This can be useful for selecting only the most important features from any set (e.g: the highest mountain peaks). But for stations, it turns out we probably want the next function.
3. `rank_features` sets a property on each matching feature which is its order in the layer. This is useful for client-side styling as, depending on the style, one might want to only show the first N features (`rank < N`) or choose to display features with `rank < N` more prominently, or just ignore it.

Connects to mapzen/vector-datasource#268.

@rmarianski could you review, please?
