### PR TITLE
Add support for dropping certain keys on labels

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1788,13 +1788,16 @@ def admin_boundaries(feature_layers, zoom, base_layer,
 
 def generate_label_features(
         feature_layers, zoom, source_layer=None, label_property_name=None,
-        label_property_value=None, new_layer_name=None):
+        label_property_value=None, new_layer_name=None, drop_keys=None):
 
     assert source_layer, 'generate_label_features: missing source_layer'
 
     layer = _find_layer(feature_layers, source_layer)
     if layer is None:
         return None
+
+    if drop_keys is None:
+        drop_keys = []
 
     new_features = []
     for feature in layer['features']:
@@ -1820,6 +1823,13 @@ def generate_label_features(
         label_point = shape.representative_point()
 
         label_properties = properties.copy()
+
+        # drop particular keys which might not be relevant any more.
+        # for example, mz_is_building, which is used by a later
+        # polygon processing stage, but irrelevant to label processing.
+        for k in drop_keys:
+            label_properties.pop(k, None)
+
         if label_property_name:
             label_properties[label_property_name] = label_property_value
 


### PR DESCRIPTION
After copying the features for labels, this can drop certain keys which aren't relevant any more on the label placements. In this case, `mz_is_building` is an internal flag used for processing landuse polygons and shouldn't be carried over to labels.

Connects to mapzen/vector-datasource#333.

@rmarianski could you review, please?
