### PR TITLE
Replaced subway lines with transit routes, but needed to update the s…

### DIFF
--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -47,20 +47,20 @@ def _sort_by_scalerank_then_population(features):
     return features
 
 
-def _by_subway_lines(feature):
+def _by_transit_routes(feature):
     wkb, props, fid = feature
 
     num_lines = 0
-    subway_lines = props.get('subway_lines')
-    if subway_lines is not None:
-        num_lines = len(subway_lines)
+    transit_routes = props.get('transit_routes')
+    if transit_routes is not None:
+        num_lines = len(transit_routes)
 
     return num_lines
 
 
-def _sort_by_subway_lines_then_feature_id(features):
+def _sort_by_transit_routes_then_feature_id(features):
     features.sort(key=_by_feature_id)
-    features.sort(key=_by_subway_lines, reverse=True)
+    features.sort(key=_by_transit_routes, reverse=True)
     return features
 
 
@@ -81,7 +81,7 @@ def places(features, zoom):
 
 
 def pois(features, zoom):
-    return _sort_by_subway_lines_then_feature_id(features)
+    return _sort_by_transit_routes_then_feature_id(features)
 
 
 def roads(features, zoom):


### PR DESCRIPTION
Forgot to update the sort functions as part of #83, and so the ordering [regressed](https://github.com/mapzen/vector-datasource/issues/268#issuecomment-152474967) to being essentially only on feature ID. This should fix that.

Connects to mapzen/vector-datasource#268.

@rmarianski could you review, please?
