### PR TITLE
Add sort by `min_zoom` to `places` layer

### DIFF
--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -86,6 +86,7 @@ def places(features, zoom):
     features.sort(key=_place_key_desc, reverse=True)
     features.sort(key=_by_scalerank)
     features.sort(key=_by_feature_property('mz_n_photos'), reverse=True)
+    features.sort(key=_by_feature_property('min_zoom'))
     return features
 
 


### PR DESCRIPTION
Refs https://github.com/mapzen/vector-datasource/issues/338

The sort for the `places` layer, in priority order, is now:
- `min_zoom` ascending
- `mz_n_photos` descending
- `scalerank` ascending
- `population` descending
- `area` descending

@zerebubuth, @nvkelso: could you review please?
