### PR TITLE
Add functions for piste routes

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -2635,7 +2635,7 @@ def remove_abandoned_pistes(
     for feature in layer['features']:
         shape, props, fid = feature
 
-        piste_abandoned = props.pop('piste_abandoned')
+        piste_abandoned = props.pop('piste_abandoned', None)
         kind = props.get('kind')
         if piste_abandoned != 'yes' or kind != 'piste':
             new_features.append(feature)


### PR DESCRIPTION
This adds processing for giving a kind to piste routes, and a post-process filter for removing routes tagged as abandoned.

Connects to mapzen/vector-datasource#342.

@rmarianski could you review, please?
