### PR TITLE
Proper kind for exit nodes.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -152,6 +152,8 @@ def _road_kind(properties):
     aerialway = properties.get('aerialway')
     if aerialway in road_kind_aerialway:
         return 'aerialway'
+    if highway == 'motorway_junction':
+        return 'exit'
     return 'minor_road'
 
 


### PR DESCRIPTION
Give exit nodes the kind 'exit', as that's a bit easier to understand than a point with kind 'minor_road'.

Connects to mapzen/vector-datasource#160.

@rmarianski could you review, please?
