### PR TITLE
Add racetracks as a kind of roads.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -154,6 +154,11 @@ def _road_kind(properties):
         return 'aerialway'
     if highway == 'motorway_junction':
         return 'exit'
+    leisure = properties.get('leisure')
+    if leisure == 'track':
+        # note: racetrack rather than track, as track might be confusing
+        # between a track for racing and a track as in a faint trail.
+        return 'racetrack'
     return 'minor_road'
 
 


### PR DESCRIPTION
This is because luge/bobsled runs appear to be mapped as `leisure=track, sport=luge`, so it seems easiest to just enable that whole class of racetracks, which include athletics tracks, karting tracks and [disc golf](https://en.wikipedia.org/wiki/Disc_golf) amongst others.

Connects to mapzen/vector-datasource#344.

@rmarianski could you review, please?
