### PR TITLE
Support matching on zoom levels

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -3138,9 +3138,10 @@ class CSVMatcher(object):
         for key in self.keys:
             # NOTE zoom is special cased
             if key == 'zoom':
-                vals.append(zoom)
+                val = zoom
             else:
-                vals.append(key)
+                val = properties.get('key')
+            vals.append(val)
         for row, target_val in self.rows:
             if all([a.match(b) for (a, b) in zip(row, vals)]):
                 return (self.target_key, target_val)


### PR DESCRIPTION
I'm not thrilled by hard coding 'zoom' as the column name to match zoom levels, but it was the first thing that popped into my head. I checked tag info, and there's a single feature that has a zoom tag, so we won't be able to write a rule to match against that feature's zoom property if we take this approach :)

@zerebubuth could you review please?

@nvkelso assuming we go forward with this idea, the way to encode the rules would be specifying a column called zoom with an int type, and then there are some additional matchers that you can use: >=, >, <=, <

For example, if you wanted to match on z>=15 for roads, you would use something like:

```
zoom::int,layer::int,kind,highway,type,railway,aeroway,service,aerialway,is_bridge,is_tunnel,sort_key
>=15,...
```

Friends with:
- https://github.com/mapzen/vector-datasource/issues/560
