### PR TITLE
Include station 'state' tag

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -3258,7 +3258,7 @@ def update_parenthetical_properties(ctx):
     return layer
 
 
-def add_construction_state_to_stations(shape, properties, fid, zoom):
+def add_state_to_stations(shape, properties, fid, zoom):
     """
     If the feature is a station, and it has a state tag, then move that
     tag to its properties.

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -3256,3 +3256,26 @@ def update_parenthetical_properties(ctx):
 
     layer['features'] = new_features
     return layer
+
+
+def add_construction_state_to_stations(shape, properties, fid, zoom):
+    """
+    If the feature is a station, and it has a state tag, then move that
+    tag to its properties.
+    """
+
+    kind = properties.get('kind')
+    if kind not in ('station'):
+        return shape, properties, fid
+
+    tags = properties.get('tags')
+    if not tags:
+        return shape, properties, fid
+
+    state = tags.get('state')
+    if not state:
+        return shape, properties, fid
+
+    properties['state'] = state
+
+    return shape, properties, fid


### PR DESCRIPTION
Adds a function which pulls the `state` tag from the tags into the properties for station POIs.

Connects to mapzen/vector-datasource#484.

@rmarianski could you review, please?
