### PR TITLE
Add `is_empty` property for geometry proxy.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -1436,6 +1436,9 @@ def exterior_boundaries(ctx):
             self.geom = geom
             self.area = area
             self._geom = geom._geom
+            # STRtree started filtering out empty geoms at some version, so
+            # we need to proxy the is_empty property.
+            self.is_empty = geom.is_empty
 
     # create an index so that we can efficiently find the
     # polygons intersecting the 'current' one. Note that


### PR DESCRIPTION
Shapely STRtree now uses the is_empty property to filter out empty geometries when building the tree.

Connects to #134.

@rmarianski could you review, please?
