### PR TITLE
Removed unused building kind calculation.

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -193,21 +193,6 @@ def remove_feature_id(shape, properties, fid, zoom):
     return shape, properties, None
 
 
-def building_kind(shape, properties, fid, zoom):
-    kind = properties.get('kind')
-    if kind:
-        return shape, properties, fid
-    building = _coalesce(properties, 'building:part', 'building')
-    if building:
-        if building != 'yes':
-            kind = building
-        else:
-            kind = 'building'
-    if kind:
-        properties['kind'] = kind
-    return shape, properties, fid
-
-
 def building_height(shape, properties, fid, zoom):
     height = _building_calc_height(
         properties.get('height'), properties.get('building:levels'),


### PR DESCRIPTION
Connects to mapzen/vector-datasource#646, requires mapzen/vector-datasource#694.

@rmarianski could you review, please?
