### PR TITLE
Filter to convert heights into meters

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -3130,3 +3130,16 @@ def add_state_to_stations(shape, properties, fid, zoom):
     properties['state'] = state
 
     return shape, properties, fid
+
+
+def height_to_meters(shape, props, fid, zoom):
+    """
+    If the properties has a "height" entry, then convert that to meters.
+    """
+
+    height = props.get('height')
+    if not height:
+        return shape, props, fid
+
+    props['height'] = _to_float_meters(height)
+    return shape, props, fid


### PR DESCRIPTION
This adds a filter function which replaces the `height` property, when present, with its equivalent in meters. The `height` property from OSM is a string with units, and these are parsed to provide a result as a float. The conversion function was updated to handle more ways of specifying units.

Connects to mapzen/vector-datasource#677.

@nvkelso could you review, please?
