### PR TITLE
Add sort order for peaks

### DIFF
--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -53,7 +53,8 @@ def _by_transit_score(feature):
 
 def _by_peak_elevation(feature):
     wkb, props, fid = feature
-    if props.get('kind') != 'peak':
+    kind = props.get('kind')
+    if kind != 'peak' and kind != 'volcano':
         return 0
     return props.get('elevation', 0)
 

--- a/TileStache/Goodies/VecTiles/sort.py
+++ b/TileStache/Goodies/VecTiles/sort.py
@@ -51,8 +51,16 @@ def _by_transit_score(feature):
     return props.get('mz_transit_score', 0)
 
 
-def _sort_by_transit_score_then_feature_id(features):
+def _by_peak_elevation(feature):
+    wkb, props, fid = feature
+    if props.get('kind') != 'peak':
+        return 0
+    return props.get('elevation', 0)
+
+
+def _sort_by_transit_score_then_elevation_then_feature_id(features):
     features.sort(key=_by_feature_id)
+    features.sort(key=_by_peak_elevation, reverse=True)
     features.sort(key=_by_transit_score, reverse=True)
     return features
 
@@ -83,7 +91,7 @@ def places(features, zoom):
 
 
 def pois(features, zoom):
-    return _sort_by_transit_score_then_feature_id(features)
+    return _sort_by_transit_score_then_elevation_then_feature_id(features)
 
 
 def roads(features, zoom):


### PR DESCRIPTION
This is so that we can give them a `kind_tile_rank` during post-processing. We sort both peaks and volcanos so that the higher peaks appear earlier in the output.

Connects to mapzen/vector-datasource#524.

@rmarianski could you review, please?
