### PR TITLE
Update building properties to use _ separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+v0.10.1
+-------
+* Update building transforms to work with `_` separated properties. The queries upstream changed to return `_` as the separator instead of `:`. See [#806](https://github.com/mapzen/vector-datasource/issues/806).
+
 v0.10.0
-------
+-------
 * Add `is_bicycle_related` transform. See [#152](https://github.com/mapzen/TileStache/pull/152).
 * Normalize cycling related properties so shared properties for `cycleway:left` and `cycleway:right` are deleted and projected into `cycleway` directly, and if `cycleway:both` is included but `cycleway` is not, project that onto `cycleway`. [#150](https://github.com/mapzen/TileStache/pull/150).
 * Don't label generate label placements for unnamed stone and rock features. See [#151](https://github.com/mapzen/TileStache/pull/151).

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -162,7 +162,7 @@ def remove_feature_id(shape, properties, fid, zoom):
 
 def building_height(shape, properties, fid, zoom):
     height = _building_calc_height(
-        properties.get('height'), properties.get('building:levels'),
+        properties.get('height'), properties.get('building_levels'),
         _building_calc_levels)
     if height is not None:
         properties['height'] = height
@@ -173,7 +173,7 @@ def building_height(shape, properties, fid, zoom):
 
 def building_min_height(shape, properties, fid, zoom):
     min_height = _building_calc_height(
-        properties.get('min_height'), properties.get('building:min_levels'),
+        properties.get('min_height'), properties.get('building_min_levels'),
         _building_calc_min_levels)
     if min_height is not None:
         properties['min_height'] = min_height
@@ -193,8 +193,8 @@ def synthesize_volume(shape, props, fid, zoom):
 def building_trim_properties(shape, properties, fid, zoom):
     properties = _remove_properties(
         properties,
-        'building', 'building:part',
-        'building:levels', 'building:min_levels')
+        'building', 'building_part',
+        'building_levels', 'building_min_levels')
     return shape, properties, fid
 
 


### PR DESCRIPTION
The queries now return the building properties with _ as the separator.

Connects to https://github.com/mapzen/vector-datasource/issues/806

@nvkelso could you review please?
