### PR TITLE
Update tags transform to convert wof l10n names

### DIFF
--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -370,7 +370,7 @@ def _convert_osm_l10n_name(x):
     except KeyError:
         # next, try a 639-2 code
         try:
-            lang = pycountry.languages.get(iso639_2_code=x)
+            lang = pycountry.languages.get(iso639_2T_code=x)
         except KeyError:
             # finally, try a 639-3 code
             try:

--- a/TileStache/Goodies/VecTiles/transform.py
+++ b/TileStache/Goodies/VecTiles/transform.py
@@ -349,6 +349,14 @@ tag_name_alternates = (
 )
 
 
+def _convert_wof_l10n_name(x):
+    assert x.startswith('name:')
+    name_val = x[len('name:'):]
+    two_letter_lang = name_val[:2]
+    result = 'name:%s' % two_letter_lang
+    return result
+
+
 def tags_name_i18n(shape, properties, fid, zoom):
     tags = properties.get('tags')
     if not tags:
@@ -358,6 +366,8 @@ def tags_name_i18n(shape, properties, fid, zoom):
     if not name:
         return shape, properties, fid
 
+    is_wof = properties.get('source') == 'whosonfirst.mapzen.com'
+
     for k, v in tags.items():
         if (k.startswith('name:') and v != name or
                 k.startswith('alt_name:') and v != name or
@@ -365,6 +375,8 @@ def tags_name_i18n(shape, properties, fid, zoom):
                 k.startswith('old_name:') and v != name or
                 k.startswith('left:name:') and v != name or
                 k.startswith('right:name:') and v != name):
+            if is_wof:
+                k = _convert_wof_l10n_name(k)
             properties[k] = v
 
     for alt_tag_name_candidate in tag_name_alternates:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def is_installed(name):
 
 
 requires = ['ModestMaps >=1.3.0', 'simplejson', 'Werkzeug',
-            'mapbox-vector-tile', 'StreetNames', 'Pillow']
+            'mapbox-vector-tile', 'StreetNames', 'Pillow', 'pycountry']
 
 
 setup(name='TileStache',


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/418

I did the fastest thing to convert to two letter language codes to match the osm convention, namely to just take the first two characters. I don't think this is right. Any thoughts as to how we should actually do the conversion? Specifically, we need to convert from 639-3 -> 639-1

@zerebubuth could you review please?
